### PR TITLE
feat(docker): run with host user instead of root user

### DIFF
--- a/raspberrypi_central/webapp/app/Dockerfile
+++ b/raspberrypi_central/webapp/app/Dockerfile
@@ -1,6 +1,12 @@
 # pull official base image
 FROM python:3.8.5-slim
 
+ARG USER_ID
+ARG GROUP_ID
+
+# add our user with its group
+RUN groupadd -f -g $GROUP_ID user && adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
+
 # set work directory
 WORKDIR /usr/src/app
 
@@ -16,10 +22,20 @@ ENV PYTHONUNBUFFERED 1
 RUN apt-get update \
     && apt-get install -y pipenv netcat gettext
 
-# install dependencies
+# upgrade python with root user
 RUN pip install --upgrade pip
+
+# run everything with this user
+USER user
+
+# add pip dependencies folder to PATH
+ENV PATH="/home/user/.local/bin:${PATH}"
+
+# install dependencies
 COPY requirements.txt /tmp/
-RUN pip install --requirement /tmp/requirements.txt
+
+# thanks to --user, pip will install everything in user directory ~/.local/bin/
+RUN pip install --user --requirement /tmp/requirements.txt
 
 # copy entrypoint.sh
 COPY ./entrypoint.sh /usr/src/app/entrypoint.sh

--- a/raspberrypi_central/webapp/app/Makefile
+++ b/raspberrypi_central/webapp/app/Makefile
@@ -8,6 +8,11 @@ db_image=database
 
 manage := $(de) $(web_image) python manage.py
 
+
+.PHONY: up
+up:
+	$(dc) up
+
 .PHONY: rabbit-services
 rabbit-services:
 	$(dc) up rabbit rabbit_worker
@@ -15,6 +20,10 @@ rabbit-services:
 .PHONY: web-services
 web-services:
 	$(dc) up celery_beat web database mqtt python_process_mqtt
+
+.PHONY: build-docker
+build-docker:
+	$(dc) build
 
 
 .PHONY: migrations

--- a/raspberrypi_central/webapp/docker-compose.yml
+++ b/raspberrypi_central/webapp/docker-compose.yml
@@ -21,7 +21,11 @@ services:
         #     timeout: 10s
         #     retries: 5
     rabbit_worker:
-        build: ./app
+        build:
+            context: ./app
+            args:
+                USER_ID: ${USER_ID}
+                GROUP_ID: ${GROUP_ID}
         command: bash -c "chmod +x ./scripts/wait-for-it.sh && ./scripts/wait-for-it.sh -t 0 rabbit:5672 -- celery -A hello_django worker --loglevel=info"
         volumes:
             - ./app/:/usr/src/app/
@@ -34,7 +38,11 @@ services:
                 ipv4_address: "172.19.0.100"
 
     celery_beat:
-        build: ./app
+        build:
+            context: ./app
+            args:
+                USER_ID: ${USER_ID}
+                GROUP_ID: ${GROUP_ID}
         volumes:
             - ./app/:/usr/src/app/
         command: bash -c "chmod +x ./scripts/wait-for-it.sh && ./scripts/wait-for-it.sh -t 0 rabbit:5672 -- celery -A hello_django beat --scheduler django_celery_beat.schedulers:DatabaseScheduler --loglevel=info"
@@ -46,7 +54,11 @@ services:
             webapp_backend:
 
     web:
-        build: ./app
+        build:
+            context: ./app
+            args:
+                USER_ID: ${USER_ID}
+                GROUP_ID: ${GROUP_ID}
         command: bash -c "chmod +x ./scripts/wait-for-it.sh && ./scripts/wait-for-it.sh -t 0 rabbit:5672 -- python manage.py runserver 0.0.0.0:8000"
         volumes:
           - ./app/:/usr/src/app/
@@ -85,7 +97,11 @@ services:
                 ipv4_address: "172.19.0.51"
 
     python_process_mqtt:
-        build: ./app
+        build:
+            context: ./app
+            args:
+                USER_ID: ${USER_ID}
+                GROUP_ID: ${GROUP_ID}
         env_file:
             - .env
         command: bash -c "chmod +x ./scripts/wait-for-it.sh && ./scripts/wait-for-it.sh -t 0 rabbit:5672 -- python standalone/mqtt/mqtt_run.py"
@@ -95,11 +111,13 @@ services:
             rabbitmq:
             webapp_backend:
             backend_mqtt:
-        env_file:
-            - .env
 
     telegram_bot:
-        build: ./app
+        build:
+            context: ./app
+            args:
+                USER_ID: ${USER_ID}
+                GROUP_ID: ${GROUP_ID}
         env_file:
             - .env
         command: python standalone/telegram_bot/bot.py
@@ -109,8 +127,6 @@ services:
             rabbitmq:
             webapp_backend:
             backend_mqtt:
-        env_file:
-            - .env
 
 networks:
     rabbitmq:


### PR DESCRIPTION
- closes #29

We now use the host user & group to run our services which are built with a custom image. Other images already take care of creating/configuring a custom user.