### PR TITLE
feat(camera): process python BytesIO to uniformize

### DIFF
--- a/raspberrypi_central/smart-camera/app/camera/webcamvideostream.py
+++ b/raspberrypi_central/smart-camera/app/camera/webcamvideostream.py
@@ -1,9 +1,11 @@
+import io
+
 import cv2
 
 
 class WebcamVideoStream:
-    def __init__(self, processFrame, resolution, framerate, src=0):
-        self.processFrame = processFrame
+    def __init__(self, process_frame, resolution, framerate, src=0):
+        self.process_frame = process_frame
 
         self.stream = cv2.VideoCapture(src)
 
@@ -33,6 +35,7 @@ class WebcamVideoStream:
             if frame is None:
                 continue
 
-            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            self.processFrame(frame)
-            # TODO issue #79: self.stream.release() to release resources when turning off the camera.
+            is_success, im_buf_arr = cv2.imencode(".jpg", frame)
+            io_buf = io.BytesIO(im_buf_arr)
+
+            self.process_frame(io_buf)

--- a/raspberrypi_central/smart-camera/app/image_processing/bin_image.py
+++ b/raspberrypi_central/smart-camera/app/image_processing/bin_image.py
@@ -1,5 +1,4 @@
 import io
-import cv2
 import numpy as np
 from PIL.Image import Image
 
@@ -13,6 +12,8 @@ def pil_image_to_byte_array(image: Image, img_format='jpeg') -> bytes:
 
 
 def cv2_image_to_byte_array(image: np.ndarray, img_format='jpg') -> bytes:
+    import cv2
+
     # encode the Numpy ndarray in the specified format.
     # im_buf is the the encoded image in an one-dimension Numpy array.
     is_success, im_buf_arr = cv2.imencode(f".{img_format}", image)


### PR DESCRIPTION
Bug introduced by #76.

At the time, I was in Estonia without any RaspberryPi, so I didn't test with the hardware.

I introduced some issues with the PiCamera and I decided to rework the thing. To day, we **have** to send `BytesIO` to process, so it is uniformized between OpenCV and PiCamera.

Before this PR, it was a numpy array.