### PR TITLE
deps: upgrade mosquitto v2 and python paho mqtt

### DIFF
--- a/raspberrypi_central/webapp/app/requirements.txt
+++ b/raspberrypi_central/webapp/app/requirements.txt
@@ -6,7 +6,7 @@ django-cors-headers==3.4.0
 django-debug-toolbar==2.2
 factory-boy==2.12.0
 faker==4.1.1
-paho-mqtt==1.5.0
+paho-mqtt==1.5.1
 celery==4.4.*
 django-celery-beat==2.0.0
 python-telegram-bot==12.8

--- a/raspberrypi_central/webapp/docker-compose.yml
+++ b/raspberrypi_central/webapp/docker-compose.yml
@@ -86,7 +86,7 @@ services:
             - '5432:5432'
 
     mqtt:
-        image: eclipse-mosquitto
+        image: eclipse-mosquitto:2.0.4
         volumes:
             - ./config/mosquitto:/mosquitto/config
             - ./mosquitto-data:/mosquitto/data


### PR DESCRIPTION
- closes #120

Didn't break any code and configuration. I just had to upgrade the docker image (from hub) and the python paho-mqtt.