### PR TITLE
feat: clean schedule tasks on delete

### DIFF
--- a/raspberrypi_central/webapp/app/alarm/tests/test_alarm_schedule.py
+++ b/raspberrypi_central/webapp/app/alarm/tests/test_alarm_schedule.py
@@ -7,11 +7,23 @@ from alarm.factories import AlarmScheduleFactory
 from alarm.models import AlarmSchedule
 from house.factories import HouseFactory
 from datetime import time
+from django_celery_beat.models import PeriodicTask
 
 
 class AlarmScheduleTestCase(TestCase):
     def setUp(self) -> None:
         HouseFactory()
+
+    def test_delete_task(self):
+        schedule = AlarmScheduleFactory()
+        tasks = PeriodicTask.objects.all()
+
+        self.assertEquals(len(tasks), 2)
+
+        schedule.delete()
+        tasks = PeriodicTask.objects.all()
+        self.assertEquals(len(tasks), 0)
+
 
     @freeze_time("2020-12-21 03:21:00")
     def test_get_next_on(self):


### PR DESCRIPTION
Issue:
- create a schedule -> it will create 2 `PeriodicTasks`: one to turn on and one to turn off the alarm.
- delete this schedule -> it won't delete the 2 related `PeriodicTasks`.

Why don't we use a delete cascade? Because we cannot, the link is: `Schedule -> PeriodicTasks`, so the `on_delete=cascade` will delete the `Schedule` if we delete the related `PeriodicTasks` but not the opposite: the `PeriodicTasks` can live without the `Schedule` in the database. But it doesn't make sens, so we delete it manually when we delete the schedule.

- :ok: change `cascade` to `protect`: if we delete a `PeriodicTasks`  linked to a `Schedule` we want to block (don't delete).