### PR TITLE
refactor(camera): frame producer and consumer to apply ia model

### DIFF
--- a/raspberrypi_central/smart-camera/app/camera/camera_producer_consumer.py
+++ b/raspberrypi_central/smart-camera/app/camera/camera_producer_consumer.py
@@ -1,0 +1,65 @@
+import io
+import multiprocessing as mp
+from queue import Empty, Full
+
+from utils.rate_limit import rate_limited
+
+
+class FrameProducer:
+    def __init__(self, queues, camera_record_event: mp.Event, camera_record_queue: mp.Queue):
+        self.queues = queues
+        self.camera_record_queue = camera_record_queue
+        self.camera_record_event = camera_record_event
+        self.camera_stream = None
+
+    def set_camera_steam(self, camera_stream):
+        self.camera_stream = camera_stream
+
+    def _manage_record(self):
+        try:
+            record_event_ref = self.camera_record_queue.get_nowait()
+        except Empty:
+            pass
+        else:
+            self.camera_stream.start_recording(record_event_ref)
+
+        if not self.camera_record_event.is_set():
+            self.camera_stream.stop_recording()
+
+    def produce(self, raw_capture):
+        self._manage_record()
+
+        # get bytes from BytesIO, image is bytes here.
+        image_bytes = raw_capture.read()
+
+        for queue in self.queues:
+            try:
+                queue.put(image_bytes, False)
+            except Full:
+                # if the Queue is full, then we ignore frames.
+                pass
+
+
+class FrameIAConsumer:
+    """
+    Take frames from queue and send it to process.
+    """
+    def __init__(self, camera):
+        self.camera = camera
+
+    def process_frame(self, queue):
+        # start mqtt connection
+        self.camera.start()
+
+        # we don't need to be thread safe because we don't use threads.
+        @rate_limited(1, thread_safe=False)
+        def process_frame():
+            try:
+                stream = io.BytesIO(queue.get_nowait())
+            except Empty:
+                pass
+            else:
+                self.camera.process_frame(stream)
+
+        while True:
+            process_frame()

--- a/raspberrypi_central/smart-camera/app/camera/camera_record.py
+++ b/raspberrypi_central/smart-camera/app/camera/camera_record.py
@@ -1,0 +1,26 @@
+import multiprocessing as mp
+from abc import ABC, abstractmethod
+
+
+class CameraRecorder(ABC):
+
+    @abstractmethod
+    def start_recording(self, video_ref: str) -> None:
+        pass
+
+    @abstractmethod
+    def stop_recording(self) -> None:
+        pass
+
+
+class CameraRecord(CameraRecorder):
+    def __init__(self, record_event: mp.Event, queue: mp.Queue):
+        self.queue = queue
+        self.record_event = record_event
+
+    def stop_recording(self):
+        self.record_event.clear()
+
+    def start_recording(self, video_ref):
+        self.record_event.set()
+        self.queue.put(video_ref)

--- a/raspberrypi_central/smart-camera/app/camera/pivideostream.py
+++ b/raspberrypi_central/smart-camera/app/camera/pivideostream.py
@@ -1,4 +1,5 @@
 import io
+import time
 
 from picamera.array import PiRGBArray
 from picamera import PiCamera
@@ -11,23 +12,39 @@ class PiVideoStream:
         self.framerate = framerate
         self.kwargs = kwargs
 
-        self._run()
+        self.camera = None
+        self._record = False
 
-    def _run(self):
-       with PiCamera() as camera:
-            camera.resolution = self.resolution
-            camera.framerate = self.framerate
+    def run(self):
+        self.camera = PiCamera()
 
-            # set optional camera parameters (refer to PiCamera docs)
-            for (arg, value) in self.kwargs.items():
-                setattr(camera, arg, value)
+        camera = self.camera
 
-            rawCapture = io.BytesIO()
-            for _ in camera.capture_continuous(rawCapture, format='jpeg'):
-                rawCapture.seek(0)
+        camera.resolution = self.resolution
+        camera.framerate = self.framerate
 
-                self.process_frame(rawCapture)
+        # set optional camera parameters (refer to PiCamera docs)
+        for (arg, value) in self.kwargs.items():
+            setattr(camera, arg, value)
 
-                # "Rewind" the stream to the beginning so we can read its content
-                rawCapture.seek(0)
-                rawCapture.truncate()
+        raw_capture = io.BytesIO()
+        for _ in camera.capture_continuous(raw_capture, format='jpeg', use_video_port=True):
+            raw_capture.seek(0)
+
+            self.process_frame(raw_capture)
+
+            # "Rewind" the stream to the beginning so we can read its content
+            raw_capture.seek(0)
+            raw_capture.truncate()
+
+    def start_recording(self, video_ref):
+        if self._record is False:
+            print('start record')
+            self._record = True
+            self.camera.start_recording(f'videos/{video_ref}.h264')
+
+    def stop_recording(self):
+        if self._record is True:
+            print('stop record')
+            self.camera.stop_recording()
+            self._record = False

--- a/raspberrypi_central/smart-camera/app/camera/pivideostream.py
+++ b/raspberrypi_central/smart-camera/app/camera/pivideostream.py
@@ -39,12 +39,10 @@ class PiVideoStream:
 
     def start_recording(self, video_ref):
         if self._record is False:
-            print('start record')
             self._record = True
             self.camera.start_recording(f'videos/{video_ref}.h264')
 
     def stop_recording(self):
         if self._record is True:
-            print('stop record')
             self.camera.stop_recording()
             self._record = False

--- a/raspberrypi_central/smart-camera/app/camera/videostream.py
+++ b/raspberrypi_central/smart-camera/app/camera/videostream.py
@@ -1,11 +1,9 @@
-class VideoStream:
-    def __init__(self, process_frame, resolution, framerate, src=0, pi_camera=False):
-
-        # If the user doesn't run the code on a PI, then the pi camera module will, very likely, crashes on import.
-        # That is why we import this module ONLY if usePiCamera is true.
-        if pi_camera is True:
-            from camera.pivideostream import PiVideoStream
-            self.stream = PiVideoStream(process_frame, resolution, framerate)
-        else:
-            from camera.webcamvideostream import WebcamVideoStream
-            self.stream = WebcamVideoStream(process_frame, resolution, framerate, src)
+def video_stream_factory(process_frame, resolution, framerate, src=0, pi_camera=False):
+    # If the user doesn't run the code on a PI, then the pi camera module will, very likely, crashes on import.
+    # That is why we import this module ONLY if usePiCamera is true.
+    if pi_camera is True:
+        from camera.pivideostream import PiVideoStream
+        return PiVideoStream(process_frame, resolution, framerate)
+    else:
+        from camera.webcamvideostream import WebcamVideoStream
+        return WebcamVideoStream(process_frame, resolution, framerate, src)

--- a/raspberrypi_central/smart-camera/app/camera/webcamvideostream.py
+++ b/raspberrypi_central/smart-camera/app/camera/webcamvideostream.py
@@ -21,12 +21,11 @@ class WebcamVideoStream:
 
         # read the first frame from the stream
         _ = self.stream.read()
-        self._update()
 
     def __del__(self):
         self.stream.release()
 
-    def _update(self):
+    def run(self):
         # keep looping infinitely until the thread is stopped
         while True:
             (_, frame) = self.stream.read()

--- a/raspberrypi_central/smart-camera/app/service_manager/roi_camera_from_args.py
+++ b/raspberrypi_central/smart-camera/app/service_manager/roi_camera_from_args.py
@@ -1,0 +1,60 @@
+from typing import List
+
+
+from camera.camera_config import camera_config
+from camera_analyze.all_analyzer import NoAnalyzer
+from camera_analyze.camera_analyzer import CameraAnalyzer, Consideration
+from camera_analyze.considered_by_any_analyzer import ConsideredByAnyAnalyzer
+from camera_analyze.rectangle_roi_analyzer import CameraAnalyzerRectangleROI
+from object_detection.detect_people_utils import bounding_box_from_point_and_size, resize_bounding_box
+from object_detection.model import BoundingBoxPointAndSize
+from roi.roi import RectangleROI
+
+
+CAMERA_WIDTH = camera_config.camera_width
+CAMERA_HEIGHT = camera_config.camera_height
+
+
+def roi_camera_from_args(data = None) -> CameraAnalyzer:
+    """
+    I have to manage to have multiple CameraAnalyzeObject
+    or... I might use another class to handle multiple camera analyze object,
+    so I could do stuff like, if in CameraRectangleROI and it is not someone that I know (facial recognition), then we consider the people
+    -> ring the alarm.
+    """
+
+    rois = data.get('rois', None)
+
+    analyzers: List[CameraAnalyzer] = []
+
+    if rois:
+        if 'rectangles' in rois:
+            rectangles = rois.get('rectangles')
+
+            definition_width = rois['definition_width']
+            definition_height = rois['definition_height']
+
+            for rectangle in rectangles:
+                consideration = Consideration(id=rectangle['id'], type='rectangles')
+
+                bounding_box = BoundingBoxPointAndSize(x=rectangle['x'], y=rectangle['y'], w=rectangle['w'], h=rectangle['h'])
+                bounding_box = bounding_box_from_point_and_size(bounding_box)
+
+                if CAMERA_WIDTH != definition_width or CAMERA_HEIGHT != definition_height:
+                    bounding_box = resize_bounding_box(old_img_width=definition_width, old_img_height=definition_height,
+                                                       new_img_width=CAMERA_WIDTH, new_img_height=CAMERA_HEIGHT, bounding_box=bounding_box)
+
+                rectangle_roi = RectangleROI(consideration, bounding_box)
+
+                analyzer = CameraAnalyzerRectangleROI(rectangle_roi)
+                analyzers.append(analyzer)
+
+            return ConsideredByAnyAnalyzer(analyzers)
+
+        if 'full' in rois:
+            consideration = Consideration(type='full')
+            return NoAnalyzer(consideration)
+
+        raise ValueError(f"Can't find any supported rois in {rois}.")
+    else:
+        raise ValueError(f"Can't find the key 'rois' in {data}")

--- a/raspberrypi_central/smart-camera/app/service_manager/run_camera.py
+++ b/raspberrypi_central/smart-camera/app/service_manager/run_camera.py
@@ -1,9 +1,9 @@
-import io
 import signal
 from typing import Callable
 
 from camera.camera import Camera
 from camera.camera_config import camera_config
+from camera.camera_producer_consumer import FrameProducer, FrameIAConsumer
 from camera.camera_record import CameraRecord
 
 from camera.camera_factory import camera_factory
@@ -12,10 +12,7 @@ from mqtt.mqtt_client import get_mqtt_client
 from service_manager.roi_camera_from_args import roi_camera_from_args
 from service_manager.service_manager import RunService
 
-from queue import Full, Empty
 import multiprocessing as mp
-
-from utils.rate_limit import rate_limited
 
 CAMERA_WIDTH = camera_config.camera_width
 CAMERA_HEIGHT = camera_config.camera_height
@@ -48,6 +45,11 @@ class RunSmartCamera(RunService):
         # we process one frame at the time. If we loose some frames to analyze it is not an issue.
         queue_model = mp.Queue(maxsize=1)
 
+        """
+        Use of event: start/end recording.
+        Use of queue: put the event reference (uuid) to save the video with it as a filename,
+        to be able to link the event motion with the video (and also pictures).
+        """
         camera_record_event = mp.Event()
         camera_record_queue = mp.Queue(maxsize=1)
 
@@ -88,72 +90,8 @@ class RunSmartCamera(RunService):
         new_roi = roi_camera_from_args(data)
         return new_roi != self._camera_analyze_object
 
-    def stop(self, *args) -> None:
-        pass
-
     def __str__(self):
         return 'run-smart-camera'
-
-
-class FrameProducer:
-    def __init__(self, queues, camera_record_event: mp.Event, camera_record_queue: mp.Queue):
-        self.queues = queues
-        self.camera_record_queue = camera_record_queue
-        self.camera_record_event = camera_record_event
-        self.camera_stream = None
-
-    def set_camera_steam(self, camera_stream):
-        self.camera_stream = camera_stream
-
-    def manage_record(self):
-
-        try:
-            record_event_ref = self.camera_record_queue.get_nowait()
-        except Empty:
-            pass
-        else:
-            self.camera_stream.start_recording(record_event_ref)
-
-        if not self.camera_record_event.is_set():
-            self.camera_stream.stop_recording()
-
-    def produce(self, raw_capture):
-        self.manage_record()
-
-        # get bytes from BytesIO, image is bytes here.
-        image_bytes = raw_capture.read()
-
-        for queue in self.queues:
-            try:
-                queue.put(image_bytes, False)
-            except Full:
-                # if the Queue is full, then we ignore frames.
-                pass
-
-
-class FrameIAConsumer:
-    """
-    Take frames from queue and send it to process.
-    """
-    def __init__(self, camera):
-        self.camera = camera
-
-    def process_frame(self, queue):
-        # start mqtt connection
-        self.camera.start()
-
-        # we don't need to be thread safe because we don't use threads.
-        @rate_limited(1, thread_safe=False)
-        def process_frame():
-            try:
-                stream = io.BytesIO(queue.get_nowait())
-            except Empty:
-                pass
-            else:
-                self.camera.process_frame(stream)
-
-        while True:
-            process_frame()
 
 
 def run_smart_camera_factory():

--- a/raspberrypi_central/smart-camera/app/service_manager/run_camera.py
+++ b/raspberrypi_central/smart-camera/app/service_manager/run_camera.py
@@ -1,90 +1,88 @@
-from typing import List, Callable
+import io
+import signal
+from typing import Callable
 
 from camera.camera import Camera
 from camera.camera_config import camera_config
+from camera.camera_record import CameraRecord
 
-from camera_analyze.camera_analyzer import Consideration, CameraAnalyzer
 from camera.camera_factory import camera_factory
-from camera.videostream import VideoStream
-from camera_analyze.all_analyzer import NoAnalyzer
-from camera_analyze.rectangle_roi_analyzer import CameraAnalyzerRectangleROI
-from camera_analyze.considered_by_any_analyzer import ConsideredByAnyAnalyzer
+from camera.videostream import video_stream_factory
 from mqtt.mqtt_client import get_mqtt_client
-from object_detection.detect_people_utils import bounding_box_from_point_and_size, resize_bounding_box
-from object_detection.model import BoundingBoxPointAndSize
-from roi.roi import RectangleROI
+from service_manager.roi_camera_from_args import roi_camera_from_args
 from service_manager.service_manager import RunService
 
+from queue import Full, Empty
+import multiprocessing as mp
+
+from utils.rate_limit import rate_limited
 
 CAMERA_WIDTH = camera_config.camera_width
 CAMERA_HEIGHT = camera_config.camera_height
 
 
-def roi_camera_from_args(data = None) -> CameraAnalyzer:
-    """
-    I have to manage to have multiple CameraAnalyzeObject
-    or... I might use another class to handle multiple camera analyze object,
-    so I could do stuff like, if in CameraRectangleROI and it is not someone that I know (facial recognition), then we consider the people
-    -> ring the alarm.
-    """
-
-    rois = data.get('rois', None)
-
-    analyzers: List[CameraAnalyzer] = []
-
-    if rois:
-        if 'rectangles' in rois:
-            rectangles = rois.get('rectangles')
-
-            definition_width = rois['definition_width']
-            definition_height = rois['definition_height']
-
-            for rectangle in rectangles:
-                consideration = Consideration(id=rectangle['id'], type='rectangles')
-
-                bounding_box = BoundingBoxPointAndSize(x=rectangle['x'], y=rectangle['y'], w=rectangle['w'], h=rectangle['h'])
-                bounding_box = bounding_box_from_point_and_size(bounding_box)
-
-                if CAMERA_WIDTH != definition_width or CAMERA_HEIGHT != definition_height:
-                    bounding_box = resize_bounding_box(old_img_width=definition_width, old_img_height=definition_height,
-                                                       new_img_width=CAMERA_WIDTH, new_img_height=CAMERA_HEIGHT, bounding_box=bounding_box)
-
-                rectangle_roi = RectangleROI(consideration, bounding_box)
-
-                analyzer = CameraAnalyzerRectangleROI(rectangle_roi)
-                analyzers.append(analyzer)
-
-            return ConsideredByAnyAnalyzer(analyzers)
-
-        if 'full' in rois:
-            consideration = Consideration(type='full')
-            return NoAnalyzer(consideration)
-
-        raise ValueError(f"Can't find any supported rois in {rois}.")
-    else:
-        raise ValueError(f"Can't find the key 'rois' in {data}")
-
-
 class RunSmartCamera(RunService):
 
-    def __init__(self, camera_factory: Callable[[], Camera], video_stream: Callable[[any], VideoStream]):
+    def __init__(self, camera_factory: Callable[[], Camera], video_stream):
         self._stream = None
         self._camera = None
         self._camera_analyze_object = None
         self.camera_factory = camera_factory
         self.video_stream = video_stream
 
+        self.capture_proc = None
+        self.consumer_proc = None
+
     def prepare_run(self, data = None) -> None:
         self._camera_analyze_object = roi_camera_from_args(data)
 
         self._camera = self.camera_factory(get_mqtt_client, self._camera_analyze_object)
 
+    def _exit_gracefully(self, signum, frame):
+        self.capture_proc.terminate()
+        self.consumer_proc.terminate()
+
     def run(self) -> None:
-        self._camera.start()
+        queue = mp.Queue(maxsize=10)
+
+        # we process one frame at the time. If we loose some frames to analyze it is not an issue.
+        queue_model = mp.Queue(maxsize=1)
+
+        camera_record_event = mp.Event()
+        camera_record_queue = mp.Queue(maxsize=1)
+
+        frame_producer = FrameProducer([queue, queue_model], camera_record_event, camera_record_queue)
+        camera_consumer = FrameIAConsumer(self._camera)
+
+        camera_record = CameraRecord(camera_record_event, camera_record_queue)
+        self._camera.camera_recorder = camera_record
 
         # TODO: see issue #78
-        self._stream = self.video_stream(self._camera.process_frame, resolution=(
-            CAMERA_WIDTH, CAMERA_HEIGHT), framerate=1, pi_camera=True)
+        self._stream = self.video_stream(frame_producer.produce, resolution=(
+            CAMERA_WIDTH, CAMERA_HEIGHT), framerate=30, pi_camera=True)
+
+        frame_producer.set_camera_steam(self._stream)
+
+        capture_proc = mp.Process(target=self._stream.run)
+        consumer_proc = mp.Process(target=camera_consumer.process_frame, args=(queue_model,))
+
+        consumer_proc.start()
+        capture_proc.start()
+
+        self.capture_proc = capture_proc
+        self.consumer_proc = consumer_proc
+
+        signals = [
+            signal.SIGINT,
+            signal.SIGTERM,
+            # this signal produces an error: OSError: [Errno 22] Invalid argument
+            # or just make the signal doesn't work with a for loop.
+            # signal.SIGKILL,
+        ]
+
+        # warning: signal handler should be after we assign processes to self.
+        for signum in signals:
+            signal.signal(signum, self._exit_gracefully)
 
     def is_restart_necessary(self, data = None) -> bool:
         new_roi = roi_camera_from_args(data)
@@ -97,5 +95,66 @@ class RunSmartCamera(RunService):
         return 'run-smart-camera'
 
 
+class FrameProducer:
+    def __init__(self, queues, camera_record_event: mp.Event, camera_record_queue: mp.Queue):
+        self.queues = queues
+        self.camera_record_queue = camera_record_queue
+        self.camera_record_event = camera_record_event
+        self.camera_stream = None
+
+    def set_camera_steam(self, camera_stream):
+        self.camera_stream = camera_stream
+
+    def manage_record(self):
+
+        try:
+            record_event_ref = self.camera_record_queue.get_nowait()
+        except Empty:
+            pass
+        else:
+            self.camera_stream.start_recording(record_event_ref)
+
+        if not self.camera_record_event.is_set():
+            self.camera_stream.stop_recording()
+
+    def produce(self, raw_capture):
+        self.manage_record()
+
+        # get bytes from BytesIO, image is bytes here.
+        image_bytes = raw_capture.read()
+
+        for queue in self.queues:
+            try:
+                queue.put(image_bytes, False)
+            except Full:
+                # if the Queue is full, then we ignore frames.
+                pass
+
+
+class FrameIAConsumer:
+    """
+    Take frames from queue and send it to process.
+    """
+    def __init__(self, camera):
+        self.camera = camera
+
+    def process_frame(self, queue):
+        # start mqtt connection
+        self.camera.start()
+
+        # we don't need to be thread safe because we don't use threads.
+        @rate_limited(1, thread_safe=False)
+        def process_frame():
+            try:
+                stream = io.BytesIO(queue.get_nowait())
+            except Empty:
+                pass
+            else:
+                self.camera.process_frame(stream)
+
+        while True:
+            process_frame()
+
+
 def run_smart_camera_factory():
-    return RunSmartCamera(camera_factory, VideoStream)
+    return RunSmartCamera(camera_factory, video_stream_factory)

--- a/raspberrypi_central/smart-camera/app/service_manager/service_manager.py
+++ b/raspberrypi_central/smart-camera/app/service_manager/service_manager.py
@@ -14,7 +14,3 @@ class RunService(ABC):
     @abstractmethod
     def is_restart_necessary(self, data) -> bool:
         pass
-
-    @abstractmethod
-    def stop(self, *args) -> None:
-        pass

--- a/raspberrypi_central/smart-camera/app/sound/run_sound.py
+++ b/raspberrypi_central/smart-camera/app/sound/run_sound.py
@@ -13,9 +13,6 @@ class RunSound(RunService):
     def run(self, *args) -> None:
         Sound().alarm()
 
-    def stop(self, *args) -> None:
-        pass
-
 
 def run_sound_factory():
     return RunSound()

--- a/raspberrypi_central/smart-camera/app/test/test_run_camera.py
+++ b/raspberrypi_central/smart-camera/app/test/test_run_camera.py
@@ -3,7 +3,8 @@ from unittest.mock import Mock
 
 from camera.camera_config import camera_config
 from camera_analyze.camera_analyzer import Consideration
-from service_manager.run_camera import roi_camera_from_args, RunSmartCamera
+from service_manager.run_camera import RunSmartCamera
+from service_manager.roi_camera_from_args import roi_camera_from_args
 from camera_analyze.all_analyzer import NoAnalyzer
 from camera_analyze.rectangle_roi_analyzer import CameraAnalyzerRectangleROI
 from camera_analyze.considered_by_any_analyzer import ConsideredByAnyAnalyzer

--- a/raspberrypi_central/smart-camera/app/thread/thread_manager.py
+++ b/raspberrypi_central/smart-camera/app/thread/thread_manager.py
@@ -35,7 +35,6 @@ class ThreadManager:
     def _stop_process(self):
         if self._process:
             LOGGER.info(f'Stop process for {self._run_service}')
-            self._run_service.stop()
             self._process.terminate()
             self._process = None
 

--- a/raspberrypi_central/smart-camera/app/utils/rate_limit.py
+++ b/raspberrypi_central/smart-camera/app/utils/rate_limit.py
@@ -1,0 +1,38 @@
+import threading
+import time
+from functools import wraps
+
+
+def rate_limited(max_per_second: int, thread_safe=True):
+    """Rate-limits the decorated function locally, for one process."""
+    if thread_safe:
+        lock = threading.Lock()
+
+    min_interval = 1.0 / max_per_second
+
+    def decorate(func):
+        last_time_called = time.perf_counter()
+
+        @wraps(func)
+        def rate_limited_function(*args, **kwargs):
+            if thread_safe:
+                lock.acquire()
+
+            nonlocal last_time_called
+            try:
+                elapsed = time.perf_counter() - last_time_called
+                left_to_wait = min_interval - elapsed
+
+                if left_to_wait > 0:
+                    time.sleep(left_to_wait)
+
+                return func(*args, **kwargs)
+            finally:
+                last_time_called = time.perf_counter()
+
+                if thread_safe:
+                    lock.release()
+
+        return rate_limited_function
+
+    return decorate


### PR DESCRIPTION
- closes #118 

- remove the `RunService` `stop` method because it is confusing. When we launch a python `Process`, we cannot call any method on it. To clean everything, we use signals.