### PR TITLE
refactor: camera

### DIFF
--- a/raspberrypi_central/core/app/alarm/tasks.py
+++ b/raspberrypi_central/core/app/alarm/tasks.py
@@ -35,9 +35,9 @@ def h264_to_mp4(input_path, output_path = None) -> str:
     retry_kwargs={'max_retries': 5},
     default_retry_delay=3)
 def process_video(video_file: str):
-    media = os.environ['MEDIA_FOLDER']
+    videos = os.environ['VIDEO_FOLDER']
 
-    video_path = os.path.join(media, video_file)
+    video_path = os.path.join(videos, video_file)
 
     if not Path(video_path).is_file():
         raise FileNotFoundError(f'{video_path} does not exist.')

--- a/raspberrypi_central/core/app/utils/mqtt/__init__.py
+++ b/raspberrypi_central/core/app/utils/mqtt/__init__.py
@@ -3,9 +3,9 @@ from functools import partial
 from typing import List
 import logging
 import utils.date as dt_utils
+from paho.mqtt.reasoncodes import ReasonCodes
 from utils.mqtt.mqtt_data import MqttConfig, Subscription, MqttTopicSubscription, MqttTopicFilterSubscription, MqttMessage
 import paho.mqtt.client as mqtt
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,14 +15,13 @@ class MQTT:
     Wrapper around Paho MQTT.
     This enables us to wrap mqtt message to its own class to group data in a clean manner.
     """
-    def __init__(self, config: MqttConfig, mqtt_client_constructor):
+    def __init__(self, config: MqttConfig):
         self._config = config
-        self._mqtt_client_constructor = mqtt_client_constructor
         self._init_mqtt_client()
 
     def _init_mqtt_client(self):
         config = self._config
-        client: mqtt.Client = self._mqtt_client_constructor(client_id=config.client_id, protocol=mqtt.MQTTv5)
+        client: mqtt.Client = mqtt.Client(client_id=config.client_id, protocol=mqtt.MQTTv5)
 
         if config.user is not None and config.password is not None:
             client.username_pw_set(config.user, config.password)
@@ -32,18 +31,21 @@ class MQTT:
         client.on_connect = self._mqtt_on_connect
 
         # TODO: what do we do when disconnect happens? It is very bad!
-        # client.on_disconnect = self._mqtt_on_disconnect
+        client.on_disconnect = self._mqtt_on_disconnect
 
         self._client = client
 
-    def _mqtt_on_connect(self, _idk, _mqttc, _userdata, _flags, result_code: int):
-        # pylint: disable=import-outside-toplevel
-        import paho.mqtt.client as mqtt
+    def _mqtt_on_disconnect(self, _client, _userdata, rc):
+        print(f'_mqtt_on_disconnect reasoncode: {mqtt.connack_string(rc)}')
 
-        if result_code != mqtt.CONNACK_ACCEPTED:
+    def _mqtt_on_connect(self, _client, _userdata, _flags, rc: ReasonCodes, _properties):
+        # print(_client._protocol)
+        print(f'_mqtt_on_connect rc: {rc}')
+
+        if rc != mqtt.CONNACK_ACCEPTED:
             _LOGGER.error(
                 "Unable to connect to the MQTT broker: %s",
-                mqtt.connack_string(result_code),
+                mqtt.connack_string(rc),
             )
             return
 
@@ -109,4 +111,4 @@ def mqtt_factory(client_id: str = None, clean_session=False) -> MQTT:
         port=int(os.environ['MQTT_PORT'])
     )
 
-    return MQTT(mqttConfig, mqtt.Client)
+    return MQTT(mqttConfig)

--- a/raspberrypi_central/core/app/utils/mqtt/__init__.py
+++ b/raspberrypi_central/core/app/utils/mqtt/__init__.py
@@ -36,7 +36,7 @@ class MQTT:
 
         self._client = client
 
-    def _mqtt_on_connect(self, _mqttc, _userdata, _flags, result_code: int):
+    def _mqtt_on_connect(self, _idk, _mqttc, _userdata, _flags, result_code: int):
         # pylint: disable=import-outside-toplevel
         import paho.mqtt.client as mqtt
 

--- a/raspberrypi_central/core/docker-compose.yml
+++ b/raspberrypi_central/core/docker-compose.yml
@@ -30,7 +30,7 @@ services:
             - webapp_backend
 
     mqtt_broker:
-        image: eclipse-mosquitto:2.0.6
+        image: eclipse-mosquitto:2.0.7
         volumes:
             - ./config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
             - ./config/mosquitto/passwd:/mosquitto/config/passwd

--- a/raspberrypi_central/smart-camera/Makefile
+++ b/raspberrypi_central/smart-camera/Makefile
@@ -21,7 +21,7 @@ build-docker:
 
 .PHONY: test
 test:
-	$(drtest) camera python -m unittest test/test_camera_recording.py #
+	$(drtest) camera python -m unittest test/test_mqtt_manage_runnable.py #
 
 .PHONY: docker-build-release
 docker-build-release:

--- a/raspberrypi_central/smart-camera/Makefile
+++ b/raspberrypi_central/smart-camera/Makefile
@@ -21,7 +21,7 @@ build-docker:
 
 .PHONY: test
 test:
-	$(drtest) camera python -m unittest test/test_camera.py
+	$(drtest) camera python -m unittest test/test_camera_recording.py #
 
 .PHONY: docker-build-release
 docker-build-release:

--- a/raspberrypi_central/smart-camera/Makefile
+++ b/raspberrypi_central/smart-camera/Makefile
@@ -4,7 +4,7 @@ dc := USER_ID=$(user) GROUP_ID=$(group) docker-compose
 de := docker-compose exec
 
 # -f docker-compose.test.yml
-drtest := $(dc) -f docker-compose.yml run --rm
+drtest := $(dc) run --rm
 dc-prod := $(dc) -f docker-compose.yml -f docker-compose.prod.yml
 
 .PHONY: prod-up
@@ -21,7 +21,7 @@ build-docker:
 
 .PHONY: test
 test:
-	$(drtest) camera python -m unittest test/test_rate_limit.py
+	$(drtest) camera python -m unittest test/test_camera.py
 
 .PHONY: docker-build-release
 docker-build-release:

--- a/raspberrypi_central/smart-camera/app/alarm.py
+++ b/raspberrypi_central/smart-camera/app/alarm.py
@@ -1,7 +1,7 @@
 import os
 
 from service_manager.run_camera import run_smart_camera_factory
-from mqtt.mqtt_status_manage_thread import mqtt_status_manage_thread_factory
+from mqtt.mqtt_manage_runnable import MqttManageRunnable
 from thread.thread_manager import ThreadManager
 from mqtt.mqtt_client import get_mqtt
 
@@ -10,6 +10,6 @@ device_id = os.environ['DEVICE_ID']
 camera_mqtt_client = get_mqtt(f"{device_id}-camera-manager")
 
 camera_manager = ThreadManager(run_smart_camera_factory())
-mqtt_status_manage_thread_factory(device_id, 'camera', camera_mqtt_client, camera_manager, status_json=True)
+MqttManageRunnable(device_id, 'camera', camera_mqtt_client, camera_manager, status_json=True)
 
 camera_mqtt_client.client.loop_forever()

--- a/raspberrypi_central/smart-camera/app/camera/camera.py
+++ b/raspberrypi_central/smart-camera/app/camera/camera.py
@@ -1,7 +1,6 @@
 import dataclasses
 import datetime
 import json
-import os
 import uuid
 from collections import defaultdict
 from io import BytesIO
@@ -23,13 +22,9 @@ class ObjectLinkConsiderations:
 
 
 class Camera:
-
     SERVICE_NAME = 'object_detection'
-    DEVICE_ID = os.environ['DEVICE_ID']
 
     SECONDS_LAPSED_TO_PUBLISH_NO_MOTION = 10
-    SECONDS_FIRST_MOTION_VIDEO = 10
-    SECONDS_MOTION_VIDEO_SPLIT = 60
 
     MOTION = 'motion/camera'
     PICTURE = 'motion/picture'
@@ -53,7 +48,7 @@ class Camera:
 
     def start(self) -> None:
         mqtt_client = self.get_mqtt(client_name=f'{self._device_id}-{Camera.SERVICE_NAME}')
-        mqtt_client.connect_keep_status(Camera.SERVICE_NAME, Camera.DEVICE_ID)
+        mqtt_client.connect_keep_status(Camera.SERVICE_NAME, self._device_id)
         self.mqtt_client = mqtt_client.client
 
     def _need_to_publish_no_motion(self) -> bool:

--- a/raspberrypi_central/smart-camera/app/camera/camera.py
+++ b/raspberrypi_central/smart-camera/app/camera/camera.py
@@ -2,13 +2,12 @@ import dataclasses
 import datetime
 import json
 import os
-import struct
 import uuid
 from collections import defaultdict
 from io import BytesIO
-from typing import List, Callable, Optional
+from typing import List, Callable
 
-from camera.camera_record import CameraRecorder
+from camera.camera_recording import CameraRecording
 from camera_analyze.camera_analyzer import CameraAnalyzer, Consideration
 from loggers import LOGGER
 from mqtt.mqtt_client import MqttClient
@@ -30,13 +29,16 @@ class Camera:
 
     SECONDS_LAPSED_TO_PUBLISH_NO_MOTION = 10
     SECONDS_FIRST_MOTION_VIDEO = 10
+    SECONDS_MOTION_VIDEO_SPLIT = 60
+
     MOTION = 'motion/camera'
     PICTURE = 'motion/picture'
     VIDEO = 'motion/video'
     EVENT_REF_NO_MOTION = '0'
 
-    def __init__(self, analyze_motion: CameraAnalyzer, detect_people: DetectPeople, get_mqtt: Callable[[any], MqttClient], device_id: str):
-        self._camera_recorder = None
+    def __init__(self, analyze_motion: CameraAnalyzer, detect_people: DetectPeople, get_mqtt: Callable[[any], MqttClient], device_id: str, camera_recording: CameraRecording):
+        self.camera_recording = camera_recording
+
         self._analyze_motion = analyze_motion
         self._device_id = device_id
         self.get_mqtt = get_mqtt
@@ -47,9 +49,6 @@ class Camera:
         self.detect_people = detect_people
         self.event_ref = self.EVENT_REF_NO_MOTION
 
-        self.start_recording_time = None
-        self.recording_first_video = False
-        self._record_video_number = 0
         self.mqtt_client = None
 
     def start(self) -> None:
@@ -108,110 +107,79 @@ class Camera:
     def _transform_image_to_publish(image: BytesIO):
         return image.getvalue()
 
-    @staticmethod
-    def _visualize_contours(frame, considered_peoples):
-        import cv2
-
-        """
-        This method is here to debug and develop the system.
-        We draw considered_peoples contours thanks to OpenCV to the frame.
-        Why is it useful only for debugging purposes? Because this feature is done on the fly by the main system.
-        We want to send the "raw" picture without any transformation and the bounding boxes data to visualize things if the user wants it.
-        Otherwise we would impact badly the picture with unnecessary fixed drawing.
-        """
-        for object_link_consideration in considered_peoples:
-            object_link_consideration: ObjectLinkConsiderations
-            frame = cv2.drawContours(frame, [object_link_consideration.object.bounding_box.contours], 0, (0, 0, 255), 2)
-
-        return frame
-
-    def _split_recording(self, device_id: str) -> None:
-        LOGGER.info('split recording')
-        self.recording_first_video = True
-        self._publish_video_event(device_id)
-        self._camera_recorder.split_recording(f'{self.event_ref}-{self._record_video_number}', device_id)
-
-    def _publish_motion(self, payload, on_device_id: str) -> None:
+    def _publish_motion(self, payload) -> None:
         mqtt_payload = json.dumps(payload)
         LOGGER.info(f'publish motion {mqtt_payload}')
 
-        self.mqtt_client.publish(f'{self.MOTION}/{on_device_id}', mqtt_payload, retain=True, qos=1)
+        self.mqtt_client.publish(f'{self.MOTION}/{self._device_id}', mqtt_payload, retain=True, qos=1)
 
-    def _publish_video_event(self, on_device_id: str) -> None:
-        self.mqtt_client.publish(f'{self.VIDEO}/{on_device_id}/{self.event_ref}-{self._record_video_number}', qos=1)
-        self._record_video_number += 1
+    def _publish_video_event(self, video_ref: str) -> None:
+        self.mqtt_client.publish(f'{self.VIDEO}/{self._device_id}/{video_ref}', qos=1)
 
-    def _publish_image(self, frame: BytesIO, is_motion: bool, on_device_id: str) -> None:
+    def _publish_image(self, frame: BytesIO, is_motion: bool) -> None:
         byte_arr = self._transform_image_to_publish(frame)
 
         motion = '0'
         if is_motion is True:
             motion = '1'
 
-        self.mqtt_client.publish(f'{self.PICTURE}/{on_device_id}/{self.event_ref}/{motion}', byte_arr, qos=1)
+        self.mqtt_client.publish(f'{self.PICTURE}/{self._device_id}/{self.event_ref}/{motion}', byte_arr, qos=1)
 
-    def process_frame(self, frame: BytesIO, on_device_id: Optional[str] = None) -> None:
-        device_id = on_device_id or self._device_id
+    def _start_detection(self, frame: BytesIO, considerations: List[ObjectLinkConsiderations]) -> None:
+        self._last_time_people_detected = datetime.datetime.now()
+        self._initialize = False
+        self.event_ref = self.generate_event_ref()
 
+        LOGGER.info('start recording')
+        self.camera_recording.start_recording(self.event_ref)
+
+        payload = self._get_motion_payload(self.event_ref, considerations)
+        self._publish_motion(payload)
+        self._publish_image(frame, True)
+
+    def _detection(self) -> None:
+        self._last_time_people_detected = datetime.datetime.now()
+
+        video_ref = self.camera_recording.split_recording(self.event_ref)
+        if video_ref:
+            self._publish_video_event(video_ref)
+
+    def _no_more_detection(self, frame: BytesIO):
+        payload = {
+            'status': False,
+            'event_ref': self.event_ref,
+        }
+
+        LOGGER.info(f'no more motion {payload}')
+
+        LOGGER.info('stop recording')
+        video_ref = self.camera_recording.stop_recording(self.event_ref)
+
+        self._publish_video_event(video_ref)
+        self._publish_motion(payload)
+        self._publish_image(frame, False)
+
+    def process_frame(self, frame: BytesIO) -> None:
         peoples, image = self.detect_people.process_frame(frame)
 
         considered_peoples = self._considered_peoples(peoples)
         is_any_considered_object = len(considered_peoples) > 0
 
+        # first time we detect people
         if is_any_considered_object and self._last_time_people_detected is None:
-            self._initialize = False
+            self._start_detection(frame, considered_peoples)
 
-            self.event_ref = self.generate_event_ref()
-
-            if self._camera_recorder:
-                LOGGER.info('start recording')
-                self.start_recording_time = datetime.datetime.now()
-                self._camera_recorder.start_recording(f'{self.event_ref}-{self._record_video_number}', device_id)
-
-            # self._visualize_contours(frame, considered_peoples)
-            payload = self._get_motion_payload(self.event_ref, considered_peoples)
-            self._publish_motion(payload, device_id)
-            self._publish_image(frame, True, device_id)
-
+        # we continue to detect people
         if is_any_considered_object:
-            self._last_time_people_detected = datetime.datetime.now()
+            self._detection()
 
-            time_lapsed = (self.start_recording_time is not None) and (
-                datetime.datetime.now() - self.start_recording_time).seconds >= Camera.SECONDS_FIRST_MOTION_VIDEO
-
-            if time_lapsed and self.recording_first_video is False:
-                self._split_recording(device_id)
-
+        # people left (some time ago), we let the core knows
         elif self._need_to_publish_no_motion():
-            payload = {
-                'status': False,
-                'event_ref': self.event_ref,
-            }
-            LOGGER.info(f'no more motion {payload}')
-
-            if self._camera_recorder:
-                LOGGER.info('stop recording')
-                self._camera_recorder.stop_recording(device_id)
-                self._publish_video_event(device_id)
-
-            self.recording_first_video = False
-            self.start_recording_time = None
-            self._record_video_number = 0
-
-            self._publish_motion(payload, device_id)
-            self._publish_image(frame, False, device_id)
+            self._no_more_detection(frame)
 
     @staticmethod
     def generate_event_ref():
         return str(uuid.uuid4())
-
-    @property
-    def camera_recorder(self) -> CameraRecorder:
-        return self._camera_recorder
-
-    @camera_recorder.setter
-    def camera_recorder(self, value: CameraRecorder):
-        self._camera_recorder = value
 
     @property
     def analyze_motion(self):

--- a/raspberrypi_central/smart-camera/app/camera/camera_factory.py
+++ b/raspberrypi_central/smart-camera/app/camera/camera_factory.py
@@ -7,8 +7,7 @@ from .camera_recording import CameraRecording
 from mqtt.mqtt_client import get_mqtt
 
 
-def camera_factory(camera_analyze_object: CameraAnalyzer, camera_recorder: CameraRecorder) -> Camera:
+def camera_factory(device_id: str, camera_analyze_object: CameraAnalyzer, camera_recorder: CameraRecorder) -> Camera:
     detect_people = detect_people_factory()
-    device_id = os.environ['DEVICE_ID']
 
     return Camera(camera_analyze_object, detect_people, get_mqtt, device_id, CameraRecording(device_id, camera_recorder))

--- a/raspberrypi_central/smart-camera/app/camera/camera_factory.py
+++ b/raspberrypi_central/smart-camera/app/camera/camera_factory.py
@@ -2,9 +2,13 @@ import os
 from object_detection.detect_people_factory import detect_people_factory
 from .camera import Camera
 from camera_analyze.camera_analyzer import CameraAnalyzer
+from .camera_record import CameraRecorder
+from .camera_recording import CameraRecording
+from mqtt.mqtt_client import get_mqtt
 
 
-def camera_factory(get_mqtt, camera_analyze_object: CameraAnalyzer) -> Camera:
+def camera_factory(camera_analyze_object: CameraAnalyzer, camera_recorder: CameraRecorder) -> Camera:
     detect_people = detect_people_factory()
+    device_id = os.environ['DEVICE_ID']
 
-    return Camera(camera_analyze_object, detect_people, get_mqtt, os.environ['DEVICE_ID'])
+    return Camera(camera_analyze_object, detect_people, get_mqtt, device_id, CameraRecording(device_id, camera_recorder))

--- a/raspberrypi_central/smart-camera/app/camera/camera_producer_consumer.py
+++ b/raspberrypi_central/smart-camera/app/camera/camera_producer_consumer.py
@@ -3,7 +3,7 @@ import multiprocessing as mp
 from queue import Empty, Full
 from utils.rate_limit import rate_limited
 
-from camera.camera_record import CameraRecord
+from camera.camera_record import MPCameraRecorder
 
 
 class FrameProducer:
@@ -22,7 +22,7 @@ class FrameProducer:
         except Empty:
             pass
         else:
-            split_recording_video_ref = CameraRecord.is_split_recording_task(record_event_ref)
+            split_recording_video_ref = MPCameraRecorder.is_split_recording_task(record_event_ref)
             if split_recording_video_ref:
                 self.camera_stream.split_recording(split_recording_video_ref)
             else:

--- a/raspberrypi_central/smart-camera/app/camera/camera_recording.py
+++ b/raspberrypi_central/smart-camera/app/camera/camera_recording.py
@@ -27,6 +27,17 @@ class CameraRecording:
             self._camera_recorder.start_recording(f'{event_ref}-{self._record_video_number}')
 
     def _split_recording(self, event_ref: str) -> str:
+        """
+        Order the CameraRecorder to record in a new file.
+        Parameters
+        ----------
+        event_ref: The event_ref that causes the recording.
+
+        Returns
+        -------
+        If the records has been split: the video_ref that has been created.
+        Otherwise None.
+        """
         old_video_ref = f'{event_ref}-{self._record_video_number}'
 
         self._record_video_number = self._record_video_number +1
@@ -41,11 +52,12 @@ class CameraRecording:
 
         Parameters
         ----------
-        event_ref
+        event_ref: The event_ref that causes the recording.
 
         Returns
         -------
-        The record that has been split,
+        If the records split: the video_ref.
+        Otherwise None.
         """
         if self._start_recording_time is None:
             return None
@@ -64,6 +76,17 @@ class CameraRecording:
                 return self._split_recording(event_ref)
 
     def stop_recording(self, event_ref: str) -> Optional[str]:
+        """
+
+        Parameters
+        ----------
+        event_ref: The event_ref that causes the recording.
+
+        Returns
+        -------
+        If the records stop: the video_ref.
+        Otherwise None.
+        """
         if self._start_recording_time is None:
             return None
 

--- a/raspberrypi_central/smart-camera/app/dumb_camera.py
+++ b/raspberrypi_central/smart-camera/app/dumb_camera.py
@@ -21,7 +21,7 @@ device_id = None
 # sys.excepthook = my_exception_hook does not work for this case (the loki request is not sent).
 try:
     from service_manager.run_dumb_camera import RunDumbCamera
-    from mqtt.mqtt_status_manage_thread import mqtt_status_manage_thread_factory
+    from mqtt.mqtt_manage_runnable import MqttManageRunnable
     from thread.thread_manager import ThreadManager
     from mqtt.mqtt_client import get_mqtt
 
@@ -31,7 +31,7 @@ try:
 
     camera_manager = ThreadManager(RunDumbCamera())
 
-    mqtt_status_manage_thread_factory(device_id, 'camera', camera_mqtt_client, camera_manager, status_json=True)
+    MqttManageRunnable(device_id, 'camera', camera_mqtt_client, camera_manager, status_json=True)
 
     camera_mqtt_client.client.loop_forever()
 except BaseException as e:

--- a/raspberrypi_central/smart-camera/app/listen_frame.py
+++ b/raspberrypi_central/smart-camera/app/listen_frame.py
@@ -7,7 +7,7 @@ from camera.camera_factory import camera_factory
 from camera.dumb_camera import DumbCamera
 from camera_analyze.camera_analyzer import CameraAnalyzer
 from mqtt.mqtt_client import get_mqtt
-from camera.camera_record import DumbCameraRecord
+from camera.camera_record import DumbCameraRecorder
 from mqtt.mqtt_status_manage_thread import mqtt_status_manage_thread_factory
 from service_manager.roi_camera_from_args import roi_camera_from_args
 from service_manager.runnable import Runnable
@@ -55,7 +55,7 @@ class ConnectedDevices:
         camera = camera_factory(get_mqtt, camera_analyzer)
         camera.start()
 
-        camera_record = DumbCameraRecord(mqtt_client.client)
+        camera_record = DumbCameraRecorder(mqtt_client.client, device_id)
         camera.camera_recorder = camera_record
 
         self._connected_devices[device_id] = camera

--- a/raspberrypi_central/smart-camera/app/listen_frame.py
+++ b/raspberrypi_central/smart-camera/app/listen_frame.py
@@ -75,10 +75,11 @@ class FrameReceiver:
 
         camera = self._connected_devices.connected_devices.get(from_device_id, None)
         print(f'analyze picture {camera}')
+
         if camera:
             camera.process_frame(image)
 
-class CameraManager(Runnable):
+class CamerasManager(Runnable):
 
     def __init__(self, connected_devices: ConnectedDevices):
         self._connected_devices = connected_devices
@@ -98,8 +99,8 @@ class CameraManager(Runnable):
         else:
             self._connected_devices.add(device_id, camera_analyze_object)
 
-connected_devices = ConnectedDevices()
 
+connected_devices = ConnectedDevices()
 frame_receiver = FrameReceiver(connected_devices)
 
 # topics to receive frames to analyze for dumb cameras.
@@ -107,7 +108,7 @@ mqtt_client.client.subscribe(f'{DumbCamera.PICTURE_TOPIC}/+', qos=0)
 mqtt_client.client.message_callback_add(f'{DumbCamera.PICTURE_TOPIC}/+', frame_receiver.on_picture)
 
 # topics to know when a camera is up/off
-camera_manager = CameraManager(connected_devices)
+camera_manager = CamerasManager(connected_devices)
 MqttManageRunnable(DEVICE_ID, 'camera', get_mqtt(f'{DEVICE_ID}-listen-dumb-camera-manager'), camera_manager, status_json=True, multi_device=True)
 
 mqtt_client.client.loop_forever()

--- a/raspberrypi_central/smart-camera/app/mqtt/mqtt_manage_runnable.py
+++ b/raspberrypi_central/smart-camera/app/mqtt/mqtt_manage_runnable.py
@@ -7,19 +7,20 @@ from mqtt.mqtt_client import MqttClient
 from service_manager.runnable import Runnable
 
 
-class MqttStatusManageThread:
+class MqttManageRunnable:
     """
     This class synchronise the alarm status with MQTT.
     If we receive a message to switch on/off the alarm, we're doing it here.
     """
-    def __init__(self, device_id: Optional[str], service_name: str, mqtt_client: MqttClient, thread_manager: Runnable, status_json=False):
-        self._thread_manager = thread_manager
+    def __init__(self, device_id: str, service_name: str, mqtt_client: MqttClient, runnable: Runnable, status_json=False, multi_device=False):
+        self._runnable = runnable
         self._service_name = service_name
         self._status_json = status_json
 
         self._device_id = device_id
+        self._multi_device = multi_device
 
-        if device_id:
+        if multi_device is False:
             mqtt_topic = f'status/{service_name}/{device_id}'
             mqtt_client.connect_keep_status(service_name, device_id)
         else:
@@ -37,8 +38,11 @@ class MqttStatusManageThread:
 
         return split[2]
 
-    def _switch_on_or_off(self, client, userdata, msg) -> None:
-        device_id = self._device_id or self._get_device_id_from_topic(msg.topic)
+    def _switch_on_or_off(self, _client, _userdata, msg) -> None:
+        if self._multi_device is True:
+            device_id = self._get_device_id_from_topic(msg.topic)
+        else:
+            device_id = self._device_id
 
         """
         MQTT callback to decide to call on/off based on received mqtt payload.
@@ -67,7 +71,6 @@ class MqttStatusManageThread:
 
             if 'data' in message:
                 data = message['data']
-
         else:
             try:
                 # unpack always return a tuple (False,) or (True,) because we pack only one value.
@@ -83,13 +86,9 @@ class MqttStatusManageThread:
         LOGGER.info(f'Receive status {status} for {self._service_name} with data {data}')
 
         if status:
-            self._thread_manager.run(device_id, True, data=data)
+            self._runnable.run(device_id, True, data)
         else:
-            self._thread_manager.run(device_id, False)
-
-
-def mqtt_status_manage_thread_factory(*args, **kwargs):
-    return MqttStatusManageThread(*args, **kwargs)
+            self._runnable.run(device_id, False)
 
 # WIP: work with TLS.
 # os.environ['REQUESTS_CA_BUNDLE'] = "/usr/local/share/ca-certificates/ca.cert"

--- a/raspberrypi_central/smart-camera/app/mqtt/mqtt_manage_runnable.py
+++ b/raspberrypi_central/smart-camera/app/mqtt/mqtt_manage_runnable.py
@@ -83,7 +83,7 @@ class MqttManageRunnable:
                 LOGGER.critical(f'Cannot decode binary {message} for service {self._service_name}')
                 return
 
-        LOGGER.info(f'Receive status {status} for {self._service_name} with data {data}')
+        LOGGER.info(f'Receive status {status} for {self._service_name} with data {data} on device {device_id}')
 
         if status:
             self._runnable.run(device_id, True, data)

--- a/raspberrypi_central/smart-camera/app/service_manager/run_camera.py
+++ b/raspberrypi_central/smart-camera/app/service_manager/run_camera.py
@@ -23,7 +23,7 @@ DEVICE_ID = os.environ['DEVICE_ID']
 
 class RunSmartCamera(RunService):
 
-    def __init__(self, camera_factory: Callable[[CameraAnalyzer, CameraRecorder], Camera], video_stream):
+    def __init__(self, camera_factory: Callable[[str, CameraAnalyzer, CameraRecorder], Camera], video_stream):
         self._stream = None
         self._camera = None
         self._camera_analyze_object = None
@@ -59,7 +59,7 @@ class RunSmartCamera(RunService):
 
         frame_producer = FrameProducer([queue, queue_model], camera_record_event, camera_record_queue)
         camera_record = MPCameraRecorder(camera_record_event, camera_record_queue)
-        self._camera = self.camera_factory(self._camera_analyze_object, camera_record)
+        self._camera = self.camera_factory(DEVICE_ID, self._camera_analyze_object, camera_record)
 
         camera_consumer = FrameIAConsumer(self._camera)
 

--- a/raspberrypi_central/smart-camera/app/service_manager/run_camera.py
+++ b/raspberrypi_central/smart-camera/app/service_manager/run_camera.py
@@ -5,11 +5,11 @@ from typing import Callable
 from camera.camera import Camera
 from camera.camera_config import camera_config
 from camera.camera_producer_consumer import FrameProducer, FrameIAConsumer
-from camera.camera_record import MPCameraRecorder
+from camera.camera_record import MPCameraRecorder, CameraRecorder
 
 from camera.camera_factory import camera_factory
 from camera.videostream import video_stream_factory
-from mqtt.mqtt_client import get_mqtt
+from camera_analyze.camera_analyzer import CameraAnalyzer
 from service_manager.roi_camera_from_args import roi_camera_from_args
 from service_manager.service_manager import RunService
 
@@ -23,7 +23,7 @@ DEVICE_ID = os.environ['DEVICE_ID']
 
 class RunSmartCamera(RunService):
 
-    def __init__(self, camera_factory: Callable[[], Camera], video_stream):
+    def __init__(self, camera_factory: Callable[[CameraAnalyzer, CameraRecorder], Camera], video_stream):
         self._stream = None
         self._camera = None
         self._camera_analyze_object = None
@@ -37,10 +37,9 @@ class RunSmartCamera(RunService):
     def prepare_run(self, data = None) -> None:
         self._camera_analyze_object = roi_camera_from_args(data)
 
-        self._camera = self.camera_factory(get_mqtt, self._camera_analyze_object)
 
-    def _exit_gracefully(self, signum, frame):
-        self.camera_record.stop_recording(DEVICE_ID)
+    def _exit_gracefully(self, _signum, _frame):
+        # self.camera_record.stop_recording(DEVICE_ID)
         self.capture_proc.terminate()
         self.consumer_proc.terminate()
 
@@ -59,11 +58,10 @@ class RunSmartCamera(RunService):
         camera_record_queue = mp.Queue(maxsize=1)
 
         frame_producer = FrameProducer([queue, queue_model], camera_record_event, camera_record_queue)
-        camera_consumer = FrameIAConsumer(self._camera)
-
         camera_record = MPCameraRecorder(camera_record_event, camera_record_queue)
-        self.camera_record = camera_record
-        self._camera.camera_recorder = camera_record
+        self._camera = self.camera_factory(self._camera_analyze_object, camera_record)
+
+        camera_consumer = FrameIAConsumer(self._camera)
 
         # TODO: see issue #78
         self._stream = self.video_stream(frame_producer.produce, resolution=(

--- a/raspberrypi_central/smart-camera/app/service_manager/run_camera.py
+++ b/raspberrypi_central/smart-camera/app/service_manager/run_camera.py
@@ -5,7 +5,7 @@ from typing import Callable
 from camera.camera import Camera
 from camera.camera_config import camera_config
 from camera.camera_producer_consumer import FrameProducer, FrameIAConsumer
-from camera.camera_record import CameraRecord
+from camera.camera_record import MPCameraRecorder
 
 from camera.camera_factory import camera_factory
 from camera.videostream import video_stream_factory
@@ -61,7 +61,7 @@ class RunSmartCamera(RunService):
         frame_producer = FrameProducer([queue, queue_model], camera_record_event, camera_record_queue)
         camera_consumer = FrameIAConsumer(self._camera)
 
-        camera_record = CameraRecord(camera_record_event, camera_record_queue)
+        camera_record = MPCameraRecorder(camera_record_event, camera_record_queue)
         self.camera_record = camera_record
         self._camera.camera_recorder = camera_record
 

--- a/raspberrypi_central/smart-camera/app/service_manager/run_dumb_camera.py
+++ b/raspberrypi_central/smart-camera/app/service_manager/run_dumb_camera.py
@@ -10,7 +10,6 @@ from camera.dumb_camera import DumbCamera
 from camera.pivideostream import PiVideoStream
 from service_manager.service_manager import RunService
 from utils.rate_limit import rate_limited
-from camera.camera_record import DumbCameraRecorder
 
 
 CAMERA_WIDTH = camera_config.camera_width
@@ -96,9 +95,7 @@ class RunDumbCamera(RunService):
             stream.run()
             # unreachable code because .run() contains an endless loop.
         except BaseException as e:
-            tags = {}
-            tags['device'] = DEVICE_ID
-
+            tags = {'device': DEVICE_ID}
             logger.error(traceback.format_exc(),
                          extra={'tags': tags})
 

--- a/raspberrypi_central/smart-camera/app/service_manager/run_dumb_camera.py
+++ b/raspberrypi_central/smart-camera/app/service_manager/run_dumb_camera.py
@@ -10,7 +10,7 @@ from camera.dumb_camera import DumbCamera
 from camera.pivideostream import PiVideoStream
 from service_manager.service_manager import RunService
 from utils.rate_limit import rate_limited
-from camera.camera_record import DumbCameraRecord
+from camera.camera_record import DumbCameraRecorder
 
 
 CAMERA_WIDTH = camera_config.camera_width

--- a/raspberrypi_central/smart-camera/app/sound.py
+++ b/raspberrypi_central/smart-camera/app/sound.py
@@ -1,7 +1,7 @@
 import os
 
 from mqtt.mqtt_client import get_mqtt
-from mqtt.mqtt_status_manage_thread import mqtt_status_manage_thread_factory
+from mqtt.mqtt_manage_runnable import MqttManageRunnable
 from sound.run_sound import run_sound_factory
 from thread.thread_manager import ThreadManager
 
@@ -11,6 +11,6 @@ device_id = os.environ['DEVICE_ID']
 sound_mqtt_client = get_mqtt(f"{device_id}-sound")
 
 sound_manager = ThreadManager(run_sound_factory())
-mqtt_status_manage_thread_factory(device_id, 'speaker', sound_mqtt_client, sound_manager, status_json=False)
+MqttManageRunnable(device_id, 'speaker', sound_mqtt_client, sound_manager, status_json=False)
 
 sound_mqtt_client.client.loop_forever()

--- a/raspberrypi_central/smart-camera/app/test/test_camera.py
+++ b/raspberrypi_central/smart-camera/app/test/test_camera.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+from io import BytesIO
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -62,9 +63,9 @@ class TestCamera(TestCase):
         camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id, self.camera_recording_mock)
         camera.start()
         camera._transform_image_to_publish = lambda *a: []
-        camera.process_frame([])
+        camera.process_frame(BytesIO())
 
-        self.mqtt_mock.publish.assert_has_calls(self.no_motion_calls)
+        self.mqtt_mock.client.publish.assert_has_calls(self.no_motion_calls)
 
 
     def test_first_no_considered_motion_process_frame(self):
@@ -79,10 +80,9 @@ class TestCamera(TestCase):
         camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id, self.camera_recording_mock)
         camera.start()
         camera._transform_image_to_publish = lambda *a: []
-        camera.process_frame([])
+        camera.process_frame(BytesIO())
 
-        self.mqtt_mock.publish.assert_has_calls(self.no_motion_calls)
-
+        self.mqtt_mock.client.publish.assert_has_calls(self.no_motion_calls)
 
     def test_first_considered_motion(self):
         self.bounding_box_point_and_size = bounding_box_size(self.bounding_box)
@@ -100,7 +100,7 @@ class TestCamera(TestCase):
         event_ref = 'event_ref'
         camera.generate_event_ref = lambda : event_ref
 
-        camera.process_frame([])
+        camera.process_frame(BytesIO())
 
         self.analyze_object_mock.considered_objects.assert_called_once()
 
@@ -119,7 +119,7 @@ class TestCamera(TestCase):
             call(f'{self.picture_topic}/{event_ref}/1', [], qos=1)
         ]
 
-        self.mqtt_mock.publish.assert_has_calls(calls)
+        self.mqtt_mock.client.publish.assert_has_calls(calls)
 
     def test_motion_with_all_consideration(self):
         consideration1 = Consideration(type='all')
@@ -134,7 +134,7 @@ class TestCamera(TestCase):
         event_ref = 'event_ref'
         camera.generate_event_ref = lambda : event_ref
 
-        camera.process_frame([])
+        camera.process_frame(BytesIO())
 
         self.analyze_object_mock.considered_objects.assert_called_once()
 
@@ -153,7 +153,7 @@ class TestCamera(TestCase):
             call(f'{self.picture_topic}/{event_ref}/1', [], qos=1)
         ]
 
-        self.mqtt_mock.publish.assert_has_calls(calls)
+        self.mqtt_mock.client.publish.assert_has_calls(calls)
 
     def test_motion_no_more_motion(self):
         """
@@ -173,19 +173,69 @@ class TestCamera(TestCase):
         event_ref = 'event_ref'
         camera.generate_event_ref = lambda : event_ref
 
-        camera.process_frame([])
+        camera.process_frame(BytesIO())
 
-        self.assertEqual(self.mqtt_mock.publish.call_count, 2)
+        self.assertEqual(self.mqtt_mock.client.publish.call_count, 2)
         self.mqtt_mock.reset_mock()
 
         with patch('camera.camera.datetime') as mock_datetime:
             self.analyze_object_mock.considered_objects.return_value = []
 
             mock_datetime.datetime.now.return_value = datetime.now() + timedelta(seconds=Camera.SECONDS_LAPSED_TO_PUBLISH_NO_MOTION)
-            camera.process_frame([])
+            camera.process_frame(BytesIO())
 
             no_motion_payload = json.dumps({"status": False, 'event_ref': event_ref})
             no_motion_call = call(self.motion_topic, no_motion_payload, retain=True, qos=1)
             no_motion_picture_call = call(f'{self.picture_topic}/{event_ref}/0', [], qos=1)
 
-            self.mqtt_mock.publish.assert_has_calls([no_motion_call, no_motion_picture_call])
+            self.mqtt_mock.client.publish.assert_has_calls([no_motion_call, no_motion_picture_call])
+
+    def _get_camera_for_recording_test(self):
+        consideration1 = Consideration(type='all')
+
+        self.detect_motion_mock.process_frame.return_value = [self.people], []
+        self.analyze_object_mock.considered_objects.return_value = [consideration1]
+
+        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id, self.camera_recording_mock)
+        camera.start()
+        camera._transform_image_to_publish = lambda *a: []
+
+        return camera, self.camera_recording_mock
+
+    def test_start_record_video(self):
+        camera, camera_recorder_mock = self._get_camera_for_recording_test()
+
+        event_ref = 'event_ref'
+        camera.generate_event_ref = lambda : event_ref
+        camera.process_frame(BytesIO())
+        camera.process_frame(BytesIO())
+        camera_recorder_mock.start_recording.assert_called_once_with(event_ref)
+
+        camera_recorder_mock.stop_recording.assert_not_called()
+        camera_recorder_mock.split_recording.assert_called_once_with(event_ref)
+
+    def test_split_record_video(self):
+        self.detect_motion_mock.process_frame.return_value = [self.people], []
+        consideration1 = Consideration(type='rectangle', id=1)
+        consideration2 = Consideration(type='rectangle', id=2)
+        self.analyze_object_mock.considered_objects.return_value = [consideration1, consideration2]
+
+        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id, self.camera_recording_mock)
+        camera.start()
+        camera._transform_image_to_publish = lambda *a: []
+        event_ref = 'event_ref'
+        camera.generate_event_ref = lambda : event_ref
+
+        camera.process_frame(BytesIO())
+
+        video_ref = 'video_ref'
+        self.camera_recording_mock.split_recording.return_value = video_ref
+
+        self.mqtt_mock.reset_mock()
+        camera.process_frame(BytesIO())
+
+        self.camera_recording_mock.split_recording.return_value = None
+        camera.process_frame(BytesIO())
+
+        no_motion_picture_call = call(f'{self.video_topic}/{video_ref}', qos=1)
+        self.mqtt_mock.client.publish.assert_has_calls([no_motion_picture_call])

--- a/raspberrypi_central/smart-camera/app/test/test_camera.py
+++ b/raspberrypi_central/smart-camera/app/test/test_camera.py
@@ -37,6 +37,7 @@ class TestCamera(TestCase):
         self.mqtt_mock = Mock()
         self.analyze_object_mock = Mock()
         self.detect_motion_mock = Mock()
+        self.camera_recording_mock = Mock()
 
         self.no_motion_payload = json.dumps({"status": False, 'event_ref': Camera.EVENT_REF_NO_MOTION})
         self.no_motion_call = call(self.motion_topic, self.no_motion_payload, retain=True, qos=1)
@@ -58,7 +59,7 @@ class TestCamera(TestCase):
         self.detect_motion_mock.process_frame.return_value = [], []
         self.analyze_object_mock.considered_objects.return_value = []
 
-        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id)
+        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id, self.camera_recording_mock)
         camera.start()
         camera._transform_image_to_publish = lambda *a: []
         camera.process_frame([])
@@ -75,7 +76,7 @@ class TestCamera(TestCase):
         self.detect_motion_mock.process_frame.return_value = [self.people], []
         self.analyze_object_mock.considered_objects.return_value = []
 
-        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id)
+        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id, self.camera_recording_mock)
         camera.start()
         camera._transform_image_to_publish = lambda *a: []
         camera.process_frame([])
@@ -86,14 +87,13 @@ class TestCamera(TestCase):
     def test_first_considered_motion(self):
         self.bounding_box_point_and_size = bounding_box_size(self.bounding_box)
 
-
         consideration1 = Consideration(type='rectangle', id=1)
         consideration2 = Consideration(type='rectangle', id=2)
 
         self.detect_motion_mock.process_frame.return_value = [self.people], []
         self.analyze_object_mock.considered_objects.return_value = [consideration1, consideration2]
 
-        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id)
+        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id, self.camera_recording_mock)
         camera.start()
         camera._transform_image_to_publish = lambda *a: []
 
@@ -127,7 +127,7 @@ class TestCamera(TestCase):
         self.detect_motion_mock.process_frame.return_value = [self.people], []
         self.analyze_object_mock.considered_objects.return_value = [consideration1]
 
-        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id)
+        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id, self.camera_recording_mock)
         camera.start()
         camera._transform_image_to_publish = lambda *a: []
 
@@ -167,7 +167,7 @@ class TestCamera(TestCase):
         consideration2 = Consideration(type='rectangle', id=2)
         self.analyze_object_mock.considered_objects.return_value = [consideration1, consideration2]
 
-        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id)
+        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id, self.camera_recording_mock)
         camera.start()
         camera._transform_image_to_publish = lambda *a: []
         event_ref = 'event_ref'
@@ -189,75 +189,3 @@ class TestCamera(TestCase):
             no_motion_picture_call = call(f'{self.picture_topic}/{event_ref}/0', [], qos=1)
 
             self.mqtt_mock.publish.assert_has_calls([no_motion_call, no_motion_picture_call])
-
-    def _get_camera_for_recording_test(self):
-        consideration1 = Consideration(type='all')
-
-        self.detect_motion_mock.process_frame.return_value = [self.people], []
-        self.analyze_object_mock.considered_objects.return_value = [consideration1]
-
-        camera_recorder_mock = Mock()
-        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id)
-        camera.camera_recorder = camera_recorder_mock
-        camera.start()
-        camera._transform_image_to_publish = lambda *a: []
-
-        return camera, camera_recorder_mock
-
-    def test_start_record_video(self):
-        camera, camera_recorder_mock = self._get_camera_for_recording_test()
-
-        event_ref = 'event_ref'
-        camera.generate_event_ref = lambda : event_ref
-        camera.process_frame([])
-        camera.process_frame([])
-        camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
-        camera_recorder_mock.stop_recording.assert_not_called()
-        camera_recorder_mock.split_recording.assert_not_called()
-
-    def test_split_record_video(self):
-        camera, camera_recorder_mock = self._get_camera_for_recording_test()
-
-        event_ref = 'event_ref'
-        camera.generate_event_ref = lambda : event_ref
-        camera.process_frame([])
-        camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
-
-        with patch('camera.camera.datetime') as mock_datetime:
-            mock_datetime.datetime.now.return_value = datetime.now() + timedelta(seconds=Camera.SECONDS_FIRST_MOTION_VIDEO)
-
-            self.mqtt_mock.reset_mock()
-            camera.process_frame([])
-            camera.process_frame([])
-
-            camera_recorder_mock.split_recording.assert_called_once_with(f'{event_ref}-1')
-            camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
-            camera_recorder_mock.stop_recording.assert_not_called()
-
-            no_motion_picture_call = call(f'{self.video_topic}/{event_ref}-0', qos=1)
-            self.mqtt_mock.publish.assert_has_calls([no_motion_picture_call])
-
-    def test_stop_record_video(self):
-        camera, camera_recorder_mock = self._get_camera_for_recording_test()
-
-        event_ref = 'event_ref'
-        camera.generate_event_ref = lambda : event_ref
-        camera.process_frame([])
-        camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
-
-        with patch('camera.camera.datetime') as mock_datetime:
-            self.mqtt_mock.reset_mock()
-            self.detect_motion_mock.process_frame.return_value = [], []
-            self.analyze_object_mock.considered_objects.return_value = []
-            mock_datetime.datetime.now.return_value = datetime.now() + timedelta(seconds=Camera.SECONDS_LAPSED_TO_PUBLISH_NO_MOTION)
-
-            camera._split_recording()
-            camera.process_frame([])
-            camera_recorder_mock.stop_recording.assert_called_once_with()
-
-            no_motion_payload = json.dumps({"status": False, 'event_ref': event_ref})
-            no_motion_call = call(self.motion_topic, no_motion_payload, retain=True, qos=1)
-
-            split_video_call = call(f'{self.video_topic}/{event_ref}-0', qos=1)
-            video_call = call(f'{self.video_topic}/{event_ref}-1', qos=1)
-            self.mqtt_mock.publish.assert_has_calls([split_video_call, video_call, no_motion_call])

--- a/raspberrypi_central/smart-camera/app/test/test_camera_producer_consumer.py
+++ b/raspberrypi_central/smart-camera/app/test/test_camera_producer_consumer.py
@@ -5,7 +5,7 @@ from camera.camera_producer_consumer import FrameProducer
 from unittest.mock import Mock
 import multiprocessing as mp
 
-from camera.camera_record import CameraRecord
+from camera.camera_record import MPCameraRecorder
 
 
 class TestFrameProducer(TestCase):
@@ -19,7 +19,7 @@ class TestFrameProducer(TestCase):
 
         video_ref = str(uuid.uuid4())
 
-        recorder = CameraRecord(camera_record_event, camera_record_queue)
+        recorder = MPCameraRecorder(camera_record_event, camera_record_queue)
         producer = FrameProducer([], camera_record_event, camera_record_queue)
         producer.set_camera_steam(camera_mock)
 
@@ -35,7 +35,7 @@ class TestFrameProducer(TestCase):
         camera_mock.reset_mock()
 
         video_ref = str(uuid.uuid4())
-        video_ref = f'{CameraRecord.SPLIT_RECORDING_TASK}/{video_ref}'
+        video_ref = f'{MPCameraRecorder.SPLIT_RECORDING_TASK}/{video_ref}'
         recorder.split_recording(video_ref)
         producer._manage_record()
 

--- a/raspberrypi_central/smart-camera/app/test/test_camera_recording.py
+++ b/raspberrypi_central/smart-camera/app/test/test_camera_recording.py
@@ -1,99 +1,62 @@
-from unittest import TestCase
-from unittest.mock import Mock, patch
+import json
+from io import BytesIO
+from unittest import TestCase, skip
+from unittest.mock import Mock, patch, call
 
 from camera.camera import Camera
-from camera_analyze.camera_analyzer import Consideration
+from camera.camera_recording import CameraRecording
 from datetime import datetime, timedelta
-
-from object_detection.detect_people_utils import bounding_box_size
-from object_detection.model import BoundingBox, People
 
 
 class TestCameraRecording(TestCase):
     def setUp(self) -> None:
-        self.device_id = 'some_id'
-        self.motion_topic = f'{Camera.MOTION}/{self.device_id}'
-        self.video_topic = f'{Camera.VIDEO}/{self.device_id}'
-        self.picture_topic = f'{Camera.PICTURE}/{self.device_id}'
+        self.device_id = 'some_uuid'
+        self.event_ref = 'some_event_ref'
 
-        self.bounding_box = BoundingBox(0, 0, 0, 0)
-        self.bounding_box_point_and_size = bounding_box_size(self.bounding_box)
-        self.people = People(self.bounding_box, 'class_id', 0.5)
-
-        self.mqtt_mock = Mock()
-        self.analyze_object_mock = Mock()
-        self.detect_motion_mock = Mock()
-        self.camera_recording_mock = Mock()
-
-
-    def _get_camera_for_recording_test(self):
-        consideration1 = Consideration(type='all')
-
-        self.detect_motion_mock.process_frame.return_value = [self.people], []
-        self.analyze_object_mock.considered_objects.return_value = [consideration1]
-
-        camera_recorder_mock = Mock()
-        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id, self.camera_recording_mock)
-        camera.camera_recorder = camera_recorder_mock
-        camera.start()
-        camera._transform_image_to_publish = lambda *a: []
-
-        return camera, camera_recorder_mock
+        self.camera_recorder_mock = Mock()
+        self.camera_recording = CameraRecording(self.device_id, self.camera_recorder_mock)
 
     def test_start_record_video(self):
-        camera, camera_recorder_mock = self._get_camera_for_recording_test()
-
-        event_ref = 'event_ref'
-        camera.generate_event_ref = lambda : event_ref
-        camera.process_frame([])
-        camera.process_frame([])
-        camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
-        camera_recorder_mock.stop_recording.assert_not_called()
-        camera_recorder_mock.split_recording.assert_not_called()
+        self.camera_recording.start_recording(self.event_ref)
+        self.camera_recording.start_recording(self.event_ref)
+        self.camera_recorder_mock.start_recording.assert_called_once_with(f'{self.event_ref}-0')
 
     def test_split_record_video(self):
-        camera, camera_recorder_mock = self._get_camera_for_recording_test()
+        self.camera_recording.start_recording(self.event_ref)
+        self.camera_recording.split_recording(self.event_ref)
 
-        event_ref = 'event_ref'
-        camera.generate_event_ref = lambda : event_ref
-        camera.process_frame([])
-        camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
+        self.camera_recorder_mock.split_recording.assert_not_called()
 
-        with patch('camera.camera.datetime') as mock_datetime:
-            mock_datetime.datetime.now.return_value = datetime.now() + timedelta(seconds=Camera.SECONDS_FIRST_MOTION_VIDEO)
+        with patch('utils.time.datetime') as mock_datetime:
+            mock_datetime.datetime.now.return_value = datetime.now() + timedelta(seconds=CameraRecording.SECONDS_FIRST_MOTION_VIDEO)
+            video_ref = self.camera_recording.split_recording(self.event_ref)
+            self.camera_recording.split_recording(self.event_ref)
 
-            self.mqtt_mock.reset_mock()
-            camera.process_frame([])
-            camera.process_frame([])
+            self.assertEqual(video_ref, f'{self.event_ref}-0')
+            self.camera_recorder_mock.split_recording.assert_called_once_with(f'{self.event_ref}-1')
 
-            camera_recorder_mock.split_recording.assert_called_once_with(f'{event_ref}-1')
-            camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
-            camera_recorder_mock.stop_recording.assert_not_called()
+        self.camera_recorder_mock.reset_mock()
 
-            no_motion_picture_call = call(f'{self.video_topic}/{event_ref}-0', qos=1)
-            self.mqtt_mock.publish.assert_has_calls([no_motion_picture_call])
+        with patch('utils.time.datetime') as mock_datetime:
+            mock_datetime.datetime.now.return_value = datetime.now() + timedelta(seconds=CameraRecording.SECONDS_MOTION_VIDEO)
+            video_ref = self.camera_recording.split_recording(self.event_ref)
+            self.assertEqual(video_ref, f'{self.event_ref}-1')
+            self.camera_recorder_mock.split_recording.assert_called_once_with(f'{self.event_ref}-2')
 
     def test_stop_record_video(self):
-        camera, camera_recorder_mock = self._get_camera_for_recording_test()
+        self.camera_recording.start_recording(self.event_ref)
 
-        event_ref = 'event_ref'
-        camera.generate_event_ref = lambda : event_ref
-        camera.process_frame([])
-        camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
+        video_ref = self.camera_recording.stop_recording(self.event_ref)
+        self.camera_recorder_mock.stop_recording.assert_called_once_with()
 
-        with patch('camera.camera.datetime') as mock_datetime:
-            self.mqtt_mock.reset_mock()
-            self.detect_motion_mock.process_frame.return_value = [], []
-            self.analyze_object_mock.considered_objects.return_value = []
-            mock_datetime.datetime.now.return_value = datetime.now() + timedelta(seconds=Camera.SECONDS_LAPSED_TO_PUBLISH_NO_MOTION)
+        self.assertEqual(video_ref, f'{self.event_ref}-0')
 
-            camera._split_recording()
-            camera.process_frame([])
-            camera_recorder_mock.stop_recording.assert_called_once_with()
+        self.camera_recorder_mock.reset_mock()
+        self.camera_recording.start_recording(self.event_ref)
 
-            no_motion_payload = json.dumps({"status": False, 'event_ref': event_ref})
-            no_motion_call = call(self.motion_topic, no_motion_payload, retain=True, qos=1)
+        with patch('utils.time.datetime') as mock_datetime:
+            mock_datetime.datetime.now.return_value = datetime.now() + timedelta(seconds=CameraRecording.SECONDS_MOTION_VIDEO)
+            video_ref = self.camera_recording.split_recording(self.event_ref)
 
-            split_video_call = call(f'{self.video_topic}/{event_ref}-0', qos=1)
-            video_call = call(f'{self.video_topic}/{event_ref}-1', qos=1)
-            self.mqtt_mock.publish.assert_has_calls([split_video_call, video_call, no_motion_call])
+        video_ref = self.camera_recording.stop_recording(self.event_ref)
+        self.assertEqual(video_ref, f'{self.event_ref}-1')

--- a/raspberrypi_central/smart-camera/app/test/test_camera_recording.py
+++ b/raspberrypi_central/smart-camera/app/test/test_camera_recording.py
@@ -1,0 +1,99 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from camera.camera import Camera
+from camera_analyze.camera_analyzer import Consideration
+from datetime import datetime, timedelta
+
+from object_detection.detect_people_utils import bounding_box_size
+from object_detection.model import BoundingBox, People
+
+
+class TestCameraRecording(TestCase):
+    def setUp(self) -> None:
+        self.device_id = 'some_id'
+        self.motion_topic = f'{Camera.MOTION}/{self.device_id}'
+        self.video_topic = f'{Camera.VIDEO}/{self.device_id}'
+        self.picture_topic = f'{Camera.PICTURE}/{self.device_id}'
+
+        self.bounding_box = BoundingBox(0, 0, 0, 0)
+        self.bounding_box_point_and_size = bounding_box_size(self.bounding_box)
+        self.people = People(self.bounding_box, 'class_id', 0.5)
+
+        self.mqtt_mock = Mock()
+        self.analyze_object_mock = Mock()
+        self.detect_motion_mock = Mock()
+        self.camera_recording_mock = Mock()
+
+
+    def _get_camera_for_recording_test(self):
+        consideration1 = Consideration(type='all')
+
+        self.detect_motion_mock.process_frame.return_value = [self.people], []
+        self.analyze_object_mock.considered_objects.return_value = [consideration1]
+
+        camera_recorder_mock = Mock()
+        camera = Camera(self.analyze_object_mock, self.detect_motion_mock, self._get_mqtt_client, self.device_id, self.camera_recording_mock)
+        camera.camera_recorder = camera_recorder_mock
+        camera.start()
+        camera._transform_image_to_publish = lambda *a: []
+
+        return camera, camera_recorder_mock
+
+    def test_start_record_video(self):
+        camera, camera_recorder_mock = self._get_camera_for_recording_test()
+
+        event_ref = 'event_ref'
+        camera.generate_event_ref = lambda : event_ref
+        camera.process_frame([])
+        camera.process_frame([])
+        camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
+        camera_recorder_mock.stop_recording.assert_not_called()
+        camera_recorder_mock.split_recording.assert_not_called()
+
+    def test_split_record_video(self):
+        camera, camera_recorder_mock = self._get_camera_for_recording_test()
+
+        event_ref = 'event_ref'
+        camera.generate_event_ref = lambda : event_ref
+        camera.process_frame([])
+        camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
+
+        with patch('camera.camera.datetime') as mock_datetime:
+            mock_datetime.datetime.now.return_value = datetime.now() + timedelta(seconds=Camera.SECONDS_FIRST_MOTION_VIDEO)
+
+            self.mqtt_mock.reset_mock()
+            camera.process_frame([])
+            camera.process_frame([])
+
+            camera_recorder_mock.split_recording.assert_called_once_with(f'{event_ref}-1')
+            camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
+            camera_recorder_mock.stop_recording.assert_not_called()
+
+            no_motion_picture_call = call(f'{self.video_topic}/{event_ref}-0', qos=1)
+            self.mqtt_mock.publish.assert_has_calls([no_motion_picture_call])
+
+    def test_stop_record_video(self):
+        camera, camera_recorder_mock = self._get_camera_for_recording_test()
+
+        event_ref = 'event_ref'
+        camera.generate_event_ref = lambda : event_ref
+        camera.process_frame([])
+        camera_recorder_mock.start_recording.assert_called_once_with(f'{event_ref}-0')
+
+        with patch('camera.camera.datetime') as mock_datetime:
+            self.mqtt_mock.reset_mock()
+            self.detect_motion_mock.process_frame.return_value = [], []
+            self.analyze_object_mock.considered_objects.return_value = []
+            mock_datetime.datetime.now.return_value = datetime.now() + timedelta(seconds=Camera.SECONDS_LAPSED_TO_PUBLISH_NO_MOTION)
+
+            camera._split_recording()
+            camera.process_frame([])
+            camera_recorder_mock.stop_recording.assert_called_once_with()
+
+            no_motion_payload = json.dumps({"status": False, 'event_ref': event_ref})
+            no_motion_call = call(self.motion_topic, no_motion_payload, retain=True, qos=1)
+
+            split_video_call = call(f'{self.video_topic}/{event_ref}-0', qos=1)
+            video_call = call(f'{self.video_topic}/{event_ref}-1', qos=1)
+            self.mqtt_mock.publish.assert_has_calls([split_video_call, video_call, no_motion_call])

--- a/raspberrypi_central/smart-camera/app/test/test_mqtt_manage_runnable.py
+++ b/raspberrypi_central/smart-camera/app/test/test_mqtt_manage_runnable.py
@@ -1,0 +1,53 @@
+import struct
+from unittest import TestCase
+from unittest.mock import Mock
+
+from mqtt.mqtt_manage_runnable import MqttManageRunnable
+
+class DotDict(dict):
+    """dot.notation access to dictionary attributes"""
+    __getattr__ = dict.get
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+
+class MqttManageRunnableTestCase(TestCase):
+    def setUp(self) -> None:
+        self.host_device_id = 'host device id'
+        self.device_id = 'some device id'
+        self.mqtt_mock = Mock()
+        self.runnable_mock = Mock()
+
+    def test_run_multi_device(self):
+        manager = MqttManageRunnable(self.host_device_id, 'listen_frame', self.mqtt_mock, self.runnable_mock, False, True)
+
+        mqtt_msg = {
+            'topic': f'camera/status/{self.device_id}',
+            'payload': struct.pack('?', True)
+        }
+
+        manager._switch_on_or_off(None, None, DotDict(mqtt_msg))
+
+        self.runnable_mock.run.assert_called_once_with(self.device_id, True, None)
+
+        self.runnable_mock.reset_mock()
+
+        mqtt_msg = {
+            'topic': f'camera/status/{self.device_id}',
+            'payload': struct.pack('?', False)
+        }
+
+        manager._switch_on_or_off(None, None, DotDict(mqtt_msg))
+        self.runnable_mock.run.assert_called_once_with(self.device_id, False)
+
+    def test_run_host(self):
+        manager = MqttManageRunnable(self.host_device_id, 'listen_frame', self.mqtt_mock, self.runnable_mock, False, False)
+
+        mqtt_msg = {
+            'topic': f'camera/status/{self.device_id}',
+            'payload': struct.pack('?', True)
+        }
+
+        manager._switch_on_or_off(None, None, DotDict(mqtt_msg))
+
+        self.runnable_mock.run.assert_called_once_with(self.host_device_id, True, None)

--- a/raspberrypi_central/smart-camera/app/utils/time.py
+++ b/raspberrypi_central/smart-camera/app/utils/time.py
@@ -1,0 +1,7 @@
+import datetime
+from typing import Optional
+
+
+def is_time_lapsed(last_time: Optional[datetime.datetime], seconds: float) -> bool:
+    return (last_time is not None) and (
+        datetime.datetime.now() - last_time).seconds >= seconds


### PR DESCRIPTION
- [x] Upgrade mosquitto 2.0.6 to 2.0.7
- [x] camera: clean factory `mqtt_status_manage_thread_factory` and related class. This abstraction (factory) is **not necessary** and causes the lost of type hints.
- [x] camera: split camera recording logic, the class `Camera` does too many things *(and that is bad)*.
- [x] :open_umbrella: add tests for recording.