### PR TITLE
upgrade celery v4 to v5

### DIFF
--- a/raspberrypi_central/core/app/requirements.txt
+++ b/raspberrypi_central/core/app/requirements.txt
@@ -5,7 +5,7 @@ django-debug-toolbar==2.2
 factory-boy==2.12.0
 faker==4.1.1
 paho-mqtt==1.5.1
-celery==4.4.*
+celery==5.0.*
 django-celery-beat==2.2.*
 python-telegram-bot==13.2
 pytz==2020.5


### PR DESCRIPTION
[Migration guide of Celery.](https://docs.celeryproject.org/en/stable/whatsnew-5.0.html). It was pretty easy as the system is already working on python >3.6 (3.8.7).