### PR TITLE
fix(docker): static ip already used

### DIFF
--- a/raspberrypi_central/core/.env.test
+++ b/raspberrypi_central/core/.env.test
@@ -1,6 +1,6 @@
 DEBUG=1
 SECRET_KEY=foo
-DJANGO_ALLOWED_HOSTS=web 172.19.0.3 192.168.1.37 localhost 127.0.0.1 [::1].
+DJANGO_ALLOWED_HOSTS=web 192.168.1.37 localhost 127.0.0.1 [::1].
 
 CELERY_BROKER_URL=amqp://admin:mypass@rabbit:5672
 

--- a/raspberrypi_central/core/docker-compose.yml
+++ b/raspberrypi_central/core/docker-compose.yml
@@ -40,7 +40,7 @@ services:
         networks:
             webapp_backend:
             backend_mqtt:
-                ipv4_address: 172.19.0.100
+                ipv4_address: 172.80.0.100
 
     rabbit_worker:
         command: bash -c "celery -A hello_django worker --loglevel=info"

--- a/raspberrypi_central/install.sh
+++ b/raspberrypi_central/install.sh
@@ -17,7 +17,7 @@ sudo usermod -aG docker pi
 # enable the pi camera. Warning: need reboot (done at the end).
 sudo raspi-config nonint do_camera 0
 
-docker network create --gateway 172.19.0.1 --subnet 172.19.0.0/16 backend_mqtt
+docker network create --gateway 172.80.0.1 --subnet 172.80.0.0/16 backend_mqtt
 docker volume create --driver local --name camera_videos
 docker plugin install grafana/loki-docker-driver:arm-v7 --alias loki --grant-all-permissions
 


### PR DESCRIPTION
During an installation, we got this error:
error: "Pool overlaps with other one on this address space" because sometimes 172.19.0.0 is already used. Go for .80 which is more exotic.

Which screwed up the whole setup (bash) process...


This fix is not bulletproof because if the new network exists the same error will happen but the 172.80.0.0 network is very less likely to be used.